### PR TITLE
feat: add think param to chat node

### DIFF
--- a/nodes/ollama-chat.html
+++ b/nodes/ollama-chat.html
@@ -14,6 +14,7 @@
             keepAlive: { value: '5m', required: false },
             keepAliveType: { value: 'str', required: false },
             tools: { value: '', type: 'ollama-config-tools', required: false },
+            think: { value: false },
             options: { value: '', type: 'ollama-config-options', required: false },
         },
         inputs: 1,
@@ -98,6 +99,11 @@
     <div class="form-row">
         <label for="node-input-tools"><i class="fa fa-cog"></i> Tools</label>
         <input type="text" id="node-input-tools" />
+    </div>
+
+    <div class="form-row">
+        <label for="node-input-think"><i class="fa fa-cog"></i> Think</label>
+        <input type="checkbox" id="node-input-think" />
     </div>
 
     <div class="form-row">

--- a/nodes/ollama-chat.js
+++ b/nodes/ollama-chat.js
@@ -8,6 +8,7 @@ module.exports = function( RED ) {
         this.messagesType = config.messagesType || 'msg'
         this.stream = config.stream || false
         this.keepAliveType = config.keepAliveType || 'str'
+        this.think = config.think || false
 
         const node = this
         node.on( 'input', async function( msg ) {
@@ -65,6 +66,8 @@ module.exports = function( RED ) {
             const toolsConfig = RED.nodes.getNode( config.tools )
             const tools = msg?.payload?.tools || ( toolsConfig ) ? JSON.parse( toolsConfig.json ) : null
 
+            const think = ( msg?.payload?.think !== undefined ) ? msg?.payload?.think : node.think
+
             const optionsConfig = RED.nodes.getNode( config.options )
             const options = msg?.payload?.options || ( optionsConfig ) ? JSON.parse( optionsConfig.json ) : null
 
@@ -75,6 +78,7 @@ module.exports = function( RED ) {
                     stream,
                     keep_alive,
                     tools,
+                    think,
                     options
                 } )
                 .catch( error => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "node-red-contrib-ollama",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-contrib-ollama",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "ollama": "^0.5.11"
+        "ollama": "^0.5.16"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/ollama": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.11.tgz",
-      "integrity": "sha512-lDAKcpmBU3VAOGF05NcQipHNKTdpKfAHpZ7bjCsElkUkmX7SNZImi6lwIxz/l1zQtLq0S3wuLneRuiXxX2KIew==",
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.5.16.tgz",
+      "integrity": "sha512-OEbxxOIUZtdZgOaTPAULo051F5y+Z1vosxEYOoABPnQKeW7i4O8tJNlxCB+xioyoorVqgjkdj+TA1f1Hy2ug/w==",
       "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.20"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "ollama": "^0.5.11"
+    "ollama": "^0.5.16"
   },
   "bugs": {
     "url": "https://github.com/jakubburkiewicz/node-red-contrib-ollama/issues"


### PR DESCRIPTION
- Update ollama package to v0.5.16
- Add think param to chat node (useful to [DeepSeek R1](https://ollama.com/library/deepseek-r1) and [Qwen 3](https://ollama.com/library/qwen3))