### PR TITLE
Update create node to fix attribute setting in node definition

### DIFF
--- a/nodes/ollama-create.html
+++ b/nodes/ollama-create.html
@@ -10,7 +10,7 @@
             model: { value: '', required: true },
             modelType: { value: "str" },
 
-            from: { value: '',  required: false },
+            from: { value: '',  required: true },
             fromType: { value: "str" },
 
             quantize: { value: '', required: false },
@@ -25,7 +25,7 @@
             system: { value: '', required: false },
             systemType: { value: "str" },
 
-            parameters: { value: '[]', required: false },
+            parameters: { value: '{}', required: false },
             parametersType: { value: "json" },
 
             messages: { value: '', required: false },

--- a/nodes/ollama-create.html
+++ b/nodes/ollama-create.html
@@ -3,92 +3,76 @@
         category: 'AI',
         color: 'rgb(186 230 253)',
         defaults: {
-            name: { value: 'Ollama Create' },
+            name: { value: '' },
             server: { value: '', type: 'ollama-config-server', required: false },
-            model: { value: '', type: 'typedInput', required: true },
-            from: { value: '', type: 'typedInput', required: true },
-            stream: { value: false, type: 'boolean', required: false },
-            quantize: { value: '', type: 'typedInput', required: true },
-            template: { value: '', type: 'typedInput', required: false },
-            license: { value: '', type: 'typedInput', required: false },
-            system: { value: '', type: 'typedInput', required: false },
-            parameters: { value: '', type: 'typedInput', required: false },
-            messages: { value: '', type: 'typedInput', required: false },
-            adapters: { value: '', type: 'typedInput', required: false }
+            stream: { value: false, required: false },
+
+            model: { value: '', required: true },
+            modelType: { value: "str" },
+
+            from: { value: '',  required: false },
+            fromType: { value: "str" },
+
+            quantize: { value: '', required: false },
+            quantizeType: { value: "str" },
+
+            template: { value: '', required: false },
+            templateType: { value: "str" },
+
+            license: { value: '', required: false },
+            licenseType: { value: "str" },
+
+            system: { value: '', required: false },
+            systemType: { value: "str" },
+
+            parameters: { value: '[]', required: false },
+            parametersType: { value: "json" },
+
+            messages: { value: '', required: false },
+            messagesType: { value: "str" },
+
+            adapters: { value: '', required: false },
+            adaptersType: { value: "str" }
         },
         inputs: 1,
         outputs: 1,
         icon: 'ollama.png',
         label: function() {
-            return this.name || 'ollama-create';
+            return this.name || (this.modelType === 'str' && this.model) || 'ollama-create';
         },
+
         oneditprepare: function() {
-            if( !this.modelType ) {
-                this.modelType = 'str'
-            }
+            [
+                "model",
+                "from",
+                "quantize",
+                "template",
+                "license",
+                "system",
+                "messages",
+                "adapters"
+            ].forEach( parameter => {
+                $( `#node-input-${parameter}` ).typedInput( {
+                    types: [ 'str', 'msg', 'flow', 'global' ],
+                    typeField: `#node-input-${parameter}Type`
+                })
+            });
 
-            $( '#node-input-model' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-modelType'
-            } )
-
-            $( '#node-input-from' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-fromType'
-            } )
-
-            $( '#node-input-quantize' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-quantizeType'
-            } )
-
-            $( '#node-input-template' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-templateType'
-            } )
-
-            $( '#node-input-license' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-licenseType'
-            } )
-
-            $( '#node-input-system' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-systemType'
-            } )
-
-            $( '#node-input-parameters' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-parametersType'
-            } )
-
-            $( '#node-input-messages' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-messagesType'
-            } )
-
-            $( '#node-input-adapters' ).typedInput( {
-                type: 'str',
-                types: [ 'str', 'msg', 'flow', 'global' ],
-                typeField: '#node-input-adaptersType'
-            } )
+            // not 'str' but 'json'
+            [
+                "parameters"
+            ].forEach( parameter => {
+                $( `#node-input-${parameter}` ).typedInput( {
+                    types: [ 'json', 'msg', 'flow', 'global' ],
+                    typeField: `#node-input-${parameter}Type`
+                })
+            });
         },
+
         oneditsave: function() {
-            this.modelfile = this.editor.getValue()
-            this.editor.destroy()
-            delete this.editor
         },
+
         oneditcancel: function() {
-            this.editor.destroy()
-            delete this.editor
         }
     } )
 </script>
@@ -117,7 +101,7 @@
     </div>
 
     <div class="form-row">
-        <label for="node-input-stream"><i class="fa fa-stream"></i> Stream</label>
+        <label for="node-input-stream"><i class="fa fa-umbrella"></i> Stream</label>
         <input type="checkbox" id="node-input-stream" />
     </div>
 
@@ -128,7 +112,7 @@
     </div>
 
     <div class="form-row">
-        <label for="node-input-template"><i class="fa fa-file-code"></i> Template</label>
+        <label for="node-input-template"><i class="fa fa-file-code-o"></i> Template</label>
         <input type="text" id="node-input-template" />
         <input type="hidden" id="node-input-templateType" />
     </div>

--- a/nodes/ollama-create.js
+++ b/nodes/ollama-create.js
@@ -4,19 +4,9 @@ module.exports = function( RED ) {
     function OllamaCreateNode( config )  {
         RED.nodes.createNode( this, config )
 
-        this.modelType = config.modelType || 'str'
-        this.fromType = config.from || 'str'
-        this.stream = config.stream || false
-        this.quantize = config.quantize || 'str'
-        this.template = config.template || null
-        this.license = config.license || null
-        this.system = config.system || null
-        this.parameters = config.parameters || 'str'
-        this.messages = config.messages || 'str'
-        this.adapters = config.adapters || 'str'
-        this.pathType = config.pathType || 'str'
-
         const node = this
+        const cfg = config
+        
         node.on( 'input', async function( msg ) {
             const server = RED.nodes.getNode( config.server )
 
@@ -52,163 +42,92 @@ module.exports = function( RED ) {
                 }
             }
 
-            const ollama = new Ollama( ollamaConfig )
+            const stream = (msg?.payload?.stream !== undefined) ? msg.payload.stream : cfg.stream
 
             let model = null
             if( msg?.payload?.model ) {
-                model = msg?.payload?.model
-            } else if( !!config.model ) {
-                if( node.modelType === 'str' ) {
-                    model = config.model
-                } else if( node.modelType === 'msg' ) {
-                    model = msg[ config.model ]
-                } else if( node.modelType === 'flow' ) {
-                    model = node.context().flow.get( config.model )
-                } else if( node.modelType === 'global' ) {
-                    model = node.context().global.get( config.model )
-                }
+                model = msg.payload.model
+            } else {
+                model = RED.util.evaluateNodeProperty(cfg.model, cfg.modelType, node, msg)
             }
 
             let from = null
             if( msg?.payload?.from ) {
-                from = msg?.payload?.from
+                from = msg.payload.from
             } else if( !!config.from ) {
-                if( node.fromType === 'str' ) {
-                    from = config.from
-                } else if( node.fromType === 'msg' ) {
-                    from = msg[ config.from ]
-                } else if( node.fromType === 'flow' ) {
-                    from = node.context().flow.get( config.from )
-                } else if( node.fromType === 'global' ) {
-                    from = node.context().global.get( config.from )
-                }
+                from = RED.util.evaluateNodeProperty(cfg.from, cfg.fromType, node, msg)                
             }
-
-            const stream = ( msg?.payload?.stream !== undefined ) ? msg?.payload?.stream : node.stream
 
             let quantize = null
             if( msg?.payload?.quantize ) {
-                quantize = msg?.payload?.quantize
+                quantize = msg.payload.quantize
             } else if( !!config.quantize ) {
-                if( node.quantize === 'str' ) {
-                    quantize = config.quantize
-                } else if( node.quantize === 'msg' ) {
-                    quantize = msg[ config.quantize ]
-                } else if( node.quantize === 'flow' ) {
-                    quantize = node.context().flow.get( config.quantize )
-                } else if( node.quantize === 'global' ) {
-                    quantize = node.context().global.get( config.quantize )
-                }
+                quantize = RED.util.evaluateNodeProperty(cfg.quantize, cfg.quantizeType, node, msg)
             }
 
             let template = null
             if( msg?.payload?.template ) {
-                template = msg?.payload?.template
+                template = msg.payload.template
             } else if( !!config.template ) {
-                if( node.template === 'str' ) {
-                    template = config.template
-                } else if( node.template === 'msg' ) {
-                    template = msg[ config.template ]
-                } else if( node.template === 'flow' ) {
-                    template = node.context().flow.get( config.template )
-                } else if( node.template === 'global' ) {
-                    template = node.context().global.get( config.template )
-                }
+                template = RED.util.evaluateNodeProperty(cfg.template, cfg.templateType, node, msg)
             }
 
             let license = null
             if( msg?.payload?.license ) {
-                license = msg?.payload?.license
+                license = msg.payload.license
             } else if( !!config.license ) {
-                if( node.license === 'str' ) {
-                    license = config.license
-                } else if( node.license === 'msg' ) {
-                    license = msg[ config.license ]
-                } else if( node.license === 'flow' ) {
-                    license = node.context().flow.get( config.license )
-                } else if( node.license === 'global' ) {
-                    license = node.context().global.get( config.license )
-                }
+                license = RED.util.evaluateNodeProperty(cfg.license, cfg.licenseType, node, msg)
             }
 
             let system = null
             if( msg?.payload?.system ) {
-                system = msg?.payload?.system
+                system = msg.payload.system
             } else if( !!config.system ) {
-                if( node.system === 'str' ) {
-                    system = config.system
-                } else if( node.system === 'msg' ) {
-                    system = msg[ config.system ]
-                } else if( node.system === 'flow' ) {
-                    system = node.context().flow.get( config.system )
-                } else if( node.system === 'global' ) {
-                    system = node.context().global.get( config.system )
-                }
+                system = RED.util.evaluateNodeProperty(cfg.system, cfg.systemType, node, msg)
             }
 
             let parameters = null
             if( msg?.payload?.parameters ) {
-                parameters = msg?.payload?.parameters
+                parameters = msg.payload.parameters
             } else if( !!config.parameters ) {
-                if( node.parameters === 'str' ) {
-                    parameters = config.parameters
-                } else if( node.parameters === 'msg' ) {
-                    parameters = msg[ config.parameters ]
-                } else if( node.parameters === 'flow' ) {
-                    parameters = node.context().flow.get( config.parameters )
-                } else if( node.parameters === 'global' ) {
-                    parameters = node.context().global.get( config.parameters )
-                }
+                parameters = RED.util.evaluateNodeProperty(cfg.parameters, cfg.parametersType, node, msg)
             }
 
             let messages = null
             if( msg?.payload?.messages ) {
-                messages = msg?.payload?.messages
+                messages = msg.payload.messages
             } else if( !!config.messages ) {
-                if( node.messages === 'str' ) {
-                    messages = config.messages
-                } else if( node.messages === 'msg' ) {
-                    messages = msg[ config.messages ]
-                } else if( node.messages === 'flow' ) {
-                    messages = node.context().flow.get( config.messages )
-                } else if( node.messages === 'global' ) {
-                    messages = node.context().global.get( config.messages )
-                }
+                messages = RED.util.evaluateNodeProperty(cfg.messages, cfg.messagesType, node, msg)
             }
 
             let adapters = null
             if( msg?.payload?.adapters ) {
-                adapters = msg?.payload?.adapters
+                adapters = msg.payload.adapters
             } else if( !!config.adapters ) {
-                if( node.adapters === 'str' ) {
-                    adapters = config.adapters
-                } else if( node.adapters === 'msg' ) {
-                    adapters = msg[ config.adapters ]
-                } else if( node.adapters === 'flow' ) {
-                    adapters = node.context().flow.get( config.adapters )
-                } else if( node.adapters === 'global' ) {
-                    adapters = node.context().global.get( config.adapters )
-                }
+                adapters = RED.util.evaluateNodeProperty(cfg.adapters, cfg.adaptersType, node, msg)
             }
+            
+            const ollama = new Ollama(ollamaConfig)
 
-            const response = await ollama.create( {
-                    model,
-                    from,
-                    stream,
-                    quantize,
-                    template,
-                    license,
-                    system,
-                    parameters,
-                    messages,
-                    adapters
-                } )
-                .catch( error => {
-                    node.error( error )
-                } )
-
-            msg.payload = response
-            node.send( msg )
+            ollama.create( {
+                model,
+                from,
+                stream,
+                quantize,
+                template,
+                license,
+                system,
+                parameters,
+                messages,
+                adapters
+            })
+            .then( response => {
+                msg.payload = response
+                node.send(msg)
+            })
+            .catch( error => {
+                node.error( error )
+            })
         } )
     }
 


### PR DESCRIPTION
The create node wasn't working for me because the nodes settings weren't being used and only`msg` values were accepted.

Changes:

- define the `xxxxType` attributes required by the node so that the `typedInput` widget can be used
- use `RED.util.evaluateNodeProperty` to obtain the values for the node configurations
- remove `await` and use `then` instead
- removed the references to an editor instance that wasn't being defined in the frontend
- removed type specification of 'typedInput' that caused errors in the browser console
- converted `parameters` attribute to being an 'json' object and not 'str'
- don't require 'quantize' - only accepted for specific model types